### PR TITLE
move boardViewController.hasClients inside callback

### DIFF
--- a/lib/board_item.dart
+++ b/lib/board_item.dart
@@ -2,7 +2,8 @@ import 'package:boardview/board_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-typedef void OnDropItem(int? listIndex, int? itemIndex,int? oldListIndex,int? oldItemIndex, BoardItemState state);
+typedef void OnDropItem(int? listIndex, int? itemIndex, int? oldListIndex,
+    int? oldItemIndex, BoardItemState state);
 typedef void OnTapItem(int? listIndex, int? itemIndex, BoardItemState state);
 typedef void OnStartDragItem(
     int? listIndex, int? itemIndex, BoardItemState state);
@@ -21,14 +22,14 @@ class BoardItem extends StatefulWidget {
 
   const BoardItem(
       {Key? key,
-        this.boardList,
-        this.item,
-        this.index,
-        this.onDropItem,
-        this.onTapItem,
-        this.onStartDragItem,
-        this.draggable = true,
-        this.onDragItem})
+      this.boardList,
+      this.item,
+      this.index,
+      this.onDropItem,
+      this.onTapItem,
+      this.onStartDragItem,
+      this.draggable = true,
+      this.onDragItem})
       : super(key: key);
 
   @override
@@ -37,7 +38,8 @@ class BoardItem extends StatefulWidget {
   }
 }
 
-class BoardItemState extends State<BoardItem> with AutomaticKeepAliveClientMixin{
+class BoardItemState extends State<BoardItem>
+    with AutomaticKeepAliveClientMixin {
   late double height;
   double? width;
 
@@ -46,20 +48,25 @@ class BoardItemState extends State<BoardItem> with AutomaticKeepAliveClientMixin
 
   void onDropItem(int? listIndex, int? itemIndex) {
     if (widget.onDropItem != null) {
-      widget.onDropItem!(listIndex, itemIndex,widget.boardList!.widget.boardView!.startListIndex,widget.boardList!.widget.boardView!.startItemIndex, this);
+      widget.onDropItem!(
+          listIndex,
+          itemIndex,
+          widget.boardList!.widget.boardView!.startListIndex,
+          widget.boardList!.widget.boardView!.startItemIndex,
+          this);
     }
     widget.boardList!.widget.boardView!.draggedItemIndex = null;
     widget.boardList!.widget.boardView!.draggedListIndex = null;
-    if(widget.boardList!.widget.boardView!.listStates[listIndex!].mounted) {
-      widget.boardList!.widget.boardView!.listStates[listIndex].setState(() { });
+    if (widget.boardList!.widget.boardView!.listStates[listIndex!].mounted) {
+      widget.boardList!.widget.boardView!.listStates[listIndex].setState(() {});
     }
   }
 
   void _startDrag(Widget item, BuildContext context) {
     if (widget.boardList!.widget.boardView != null) {
       widget.boardList!.widget.boardView!.onDropItem = onDropItem;
-      if(widget.boardList!.mounted) {
-        widget.boardList!.setState(() { });
+      if (widget.boardList!.mounted) {
+        widget.boardList!.setState(() {});
       }
       widget.boardList!.widget.boardView!.draggedItemIndex = widget.index;
       widget.boardList!.widget.boardView!.height = context.size!.height;
@@ -74,8 +81,8 @@ class BoardItemState extends State<BoardItem> with AutomaticKeepAliveClientMixin
             widget.boardList!.widget.index, widget.index, this);
       }
       widget.boardList!.widget.boardView!.run();
-      if(widget.boardList!.widget.boardView!.mounted) {
-        widget.boardList!.widget.boardView!.setState(() { });
+      if (widget.boardList!.widget.boardView!.mounted) {
+        widget.boardList!.widget.boardView!.setState(() {});
       }
     }
   }
@@ -84,12 +91,12 @@ class BoardItemState extends State<BoardItem> with AutomaticKeepAliveClientMixin
     try {
       height = context.size!.height;
       width = context.size!.width;
-    }catch(e){}
+    } catch (e) {}
   }
 
   @override
   Widget build(BuildContext context) {
-    WidgetsBinding.instance!
+    WidgetsBinding.instance
         .addPostFrameCallback((_) => afterFirstLayout(context));
     if (widget.boardList!.itemStates.length > widget.index!) {
       widget.boardList!.itemStates.removeAt(widget.index!);
@@ -97,10 +104,11 @@ class BoardItemState extends State<BoardItem> with AutomaticKeepAliveClientMixin
     widget.boardList!.itemStates.insert(widget.index!, this);
     return GestureDetector(
       onTapDown: (otd) {
-        if(widget.draggable) {
+        if (widget.draggable) {
           RenderBox object = context.findRenderObject() as RenderBox;
           Offset pos = object.localToGlobal(Offset.zero);
-          RenderBox box = widget.boardList!.context.findRenderObject() as RenderBox;
+          RenderBox box =
+              widget.boardList!.context.findRenderObject() as RenderBox;
           Offset listPos = box.localToGlobal(Offset.zero);
           widget.boardList!.widget.boardView!.leftListX = listPos.dx;
           widget.boardList!.widget.boardView!.topListY = listPos.dy;
@@ -123,7 +131,8 @@ class BoardItemState extends State<BoardItem> with AutomaticKeepAliveClientMixin
         }
       },
       onLongPress: () {
-        if(!widget.boardList!.widget.boardView!.widget.isSelecting && widget.draggable) {
+        if (!widget.boardList!.widget.boardView!.widget.isSelecting &&
+            widget.draggable) {
           _startDrag(widget, context);
         }
       },

--- a/lib/boardview.dart
+++ b/lib/boardview.dart
@@ -300,11 +300,11 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
 
   @override
   Widget build(BuildContext context) {
-    print("dy:${dy}");
-    print("topListY:${topListY}");
-    print("bottomListY:${bottomListY}");
-    if(boardViewController.hasClients) {
-      WidgetsBinding.instance!.addPostFrameCallback((Duration duration) {
+    // print("dy:${dy}");
+    // print("topListY:${topListY}");
+    // print("bottomListY:${bottomListY}");
+    WidgetsBinding.instance!.addPostFrameCallback((Duration duration) {
+      if(boardViewController.hasClients) {
         try {
           boardViewController.position.didUpdateScrollPositionBy(0);
         }catch(e){}
@@ -314,8 +314,8 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
             shown = _shown;
           });
         }
-      });
-    }
+      }
+    });
     Widget listWidget = ListView.builder(
       physics: ClampingScrollPhysics(),
       itemCount: widget.lists!.length,

--- a/lib/boardview.dart
+++ b/lib/boardview.dart
@@ -22,7 +22,20 @@ class BoardView extends StatefulWidget {
 
   Function(bool)? itemInMiddleWidget;
   OnDropBottomWidget? onDropItemInMiddleWidget;
-  BoardView({Key? key, this.itemInMiddleWidget,this.scrollbar,this.scrollbarStyle,this.boardViewController,this.dragDelay=300,this.onDropItemInMiddleWidget, this.isSelecting = false, this.lists, this.width = 280, this.middleWidget, this.bottomPadding}) : super(key: key);
+  BoardView(
+      {Key? key,
+      this.itemInMiddleWidget,
+      this.scrollbar,
+      this.scrollbarStyle,
+      this.boardViewController,
+      this.dragDelay = 300,
+      this.onDropItemInMiddleWidget,
+      this.isSelecting = false,
+      this.lists,
+      this.width = 280,
+      this.middleWidget,
+      this.bottomPadding})
+      : super(key: key);
 
   @override
   State<StatefulWidget> createState() {
@@ -30,11 +43,13 @@ class BoardView extends StatefulWidget {
   }
 }
 
-typedef void OnDropBottomWidget(int? listIndex, int? itemIndex,double percentX);
+typedef void OnDropBottomWidget(
+    int? listIndex, int? itemIndex, double percentX);
 typedef void OnDropItem(int? listIndex, int? itemIndex);
 typedef void OnDropList(int? listIndex);
 
-class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin {
+class BoardViewState extends State<BoardView>
+    with AutomaticKeepAliveClientMixin {
   Widget? draggedItem;
   int? draggedItemIndex;
   int? draggedListIndex;
@@ -79,49 +94,65 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
   @override
   void initState() {
     super.initState();
-    if(widget.boardViewController != null){
+    if (widget.boardViewController != null) {
       widget.boardViewController!.state = this;
     }
   }
 
   void moveDown() {
-    if(topItemY != null){
-      topItemY = topItemY! + listStates[draggedListIndex!].itemStates[draggedItemIndex! + 1].height;
+    if (topItemY != null) {
+      topItemY = topItemY! +
+          listStates[draggedListIndex!]
+              .itemStates[draggedItemIndex! + 1]
+              .height;
     }
-    if(bottomItemY != null){
-      bottomItemY = bottomItemY! + listStates[draggedListIndex!].itemStates[draggedItemIndex! + 1].height;
+    if (bottomItemY != null) {
+      bottomItemY = bottomItemY! +
+          listStates[draggedListIndex!]
+              .itemStates[draggedItemIndex! + 1]
+              .height;
     }
     var item = widget.lists![draggedListIndex!].items![draggedItemIndex!];
     widget.lists![draggedListIndex!].items!.removeAt(draggedItemIndex!);
     var itemState = listStates[draggedListIndex!].itemStates[draggedItemIndex!];
     listStates[draggedListIndex!].itemStates.removeAt(draggedItemIndex!);
-    if(draggedItemIndex != null){
+    if (draggedItemIndex != null) {
       draggedItemIndex = draggedItemIndex! + 1;
     }
     widget.lists![draggedListIndex!].items!.insert(draggedItemIndex!, item);
-    listStates[draggedListIndex!].itemStates.insert(draggedItemIndex!, itemState);
-    if(listStates[draggedListIndex!].mounted) {
+    listStates[draggedListIndex!]
+        .itemStates
+        .insert(draggedItemIndex!, itemState);
+    if (listStates[draggedListIndex!].mounted) {
       listStates[draggedListIndex!].setState(() {});
     }
   }
 
   void moveUp() {
-    if(topItemY != null){
-      topItemY = topItemY! - listStates[draggedListIndex!].itemStates[draggedItemIndex! - 1].height;
+    if (topItemY != null) {
+      topItemY = topItemY! -
+          listStates[draggedListIndex!]
+              .itemStates[draggedItemIndex! - 1]
+              .height;
     }
-    if(bottomItemY != null){
-      bottomItemY = bottomItemY!-listStates[draggedListIndex!].itemStates[draggedItemIndex! - 1].height;
+    if (bottomItemY != null) {
+      bottomItemY = bottomItemY! -
+          listStates[draggedListIndex!]
+              .itemStates[draggedItemIndex! - 1]
+              .height;
     }
     var item = widget.lists![draggedListIndex!].items![draggedItemIndex!];
     widget.lists![draggedListIndex!].items!.removeAt(draggedItemIndex!);
     var itemState = listStates[draggedListIndex!].itemStates[draggedItemIndex!];
     listStates[draggedListIndex!].itemStates.removeAt(draggedItemIndex!);
-    if(draggedItemIndex != null){
+    if (draggedItemIndex != null) {
       draggedItemIndex = draggedItemIndex! - 1;
     }
     widget.lists![draggedListIndex!].items!.insert(draggedItemIndex!, item);
-    listStates[draggedListIndex!].itemStates.insert(draggedItemIndex!, itemState);
-    if(listStates[draggedListIndex!].mounted) {
+    listStates[draggedListIndex!]
+        .itemStates
+        .insert(draggedItemIndex!, itemState);
+    if (listStates[draggedListIndex!].mounted) {
       listStates[draggedListIndex!].setState(() {});
     }
   }
@@ -131,7 +162,7 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
     var listState = listStates[draggedListIndex!];
     widget.lists!.removeAt(draggedListIndex!);
     listStates.removeAt(draggedListIndex!);
-    if(draggedListIndex != null){
+    if (draggedListIndex != null) {
       draggedListIndex = draggedListIndex! + 1;
     }
     widget.lists!.insert(draggedListIndex!, list);
@@ -140,9 +171,11 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
     if (boardViewController != null && boardViewController.hasClients) {
       int? tempListIndex = draggedListIndex;
       boardViewController
-          .animateTo(draggedListIndex! * widget.width, duration: new Duration(milliseconds: 400), curve: Curves.ease)
+          .animateTo(draggedListIndex! * widget.width,
+              duration: new Duration(milliseconds: 400), curve: Curves.ease)
           .whenComplete(() {
-        RenderBox object = listStates[tempListIndex!].context.findRenderObject() as RenderBox;
+        RenderBox object =
+            listStates[tempListIndex!].context.findRenderObject() as RenderBox;
         Offset pos = object.localToGlobal(Offset.zero);
         leftListX = pos.dx;
         rightListX = pos.dx + object.size.width;
@@ -151,7 +184,7 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
         });
       });
     }
-    if(mounted){
+    if (mounted) {
       setState(() {});
     }
   }
@@ -161,17 +194,21 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
     var itemState = listStates[draggedListIndex!].itemStates[draggedItemIndex!];
     widget.lists![draggedListIndex!].items!.removeAt(draggedItemIndex!);
     listStates[draggedListIndex!].itemStates.removeAt(draggedItemIndex!);
-    if(listStates[draggedListIndex!].mounted) {
+    if (listStates[draggedListIndex!].mounted) {
       listStates[draggedListIndex!].setState(() {});
     }
-    if(draggedListIndex != null){
+    if (draggedListIndex != null) {
       draggedListIndex = draggedListIndex! + 1;
     }
     double closestValue = 10000;
     draggedItemIndex = 0;
     for (int i = 0; i < listStates[draggedListIndex!].itemStates.length; i++) {
-      if (listStates[draggedListIndex!].itemStates[i].mounted && listStates[draggedListIndex!].itemStates[i].context != null) {
-        RenderBox box = listStates[draggedListIndex!].itemStates[i].context.findRenderObject() as RenderBox;
+      if (listStates[draggedListIndex!].itemStates[i].mounted &&
+          listStates[draggedListIndex!].itemStates[i].context != null) {
+        RenderBox box = listStates[draggedListIndex!]
+            .itemStates[i]
+            .context
+            .findRenderObject() as RenderBox;
         Offset pos = box.localToGlobal(Offset.zero);
         var temp = (pos.dy - dy! + (box.size.height / 2)).abs();
         if (temp < closestValue) {
@@ -182,22 +219,29 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
       }
     }
     widget.lists![draggedListIndex!].items!.insert(draggedItemIndex!, item);
-    listStates[draggedListIndex!].itemStates.insert(draggedItemIndex!, itemState);
+    listStates[draggedListIndex!]
+        .itemStates
+        .insert(draggedItemIndex!, itemState);
     canDrag = false;
-    if(listStates[draggedListIndex!].mounted) {
+    if (listStates[draggedListIndex!].mounted) {
       listStates[draggedListIndex!].setState(() {});
     }
     if (boardViewController != null && boardViewController.hasClients) {
       int? tempListIndex = draggedListIndex;
       int? tempItemIndex = draggedItemIndex;
       boardViewController
-          .animateTo(draggedListIndex! * widget.width, duration: new Duration(milliseconds: 400), curve: Curves.ease)
+          .animateTo(draggedListIndex! * widget.width,
+              duration: new Duration(milliseconds: 400), curve: Curves.ease)
           .whenComplete(() {
-        RenderBox object = listStates[tempListIndex!].context.findRenderObject() as RenderBox;
+        RenderBox object =
+            listStates[tempListIndex!].context.findRenderObject() as RenderBox;
         Offset pos = object.localToGlobal(Offset.zero);
         leftListX = pos.dx;
         rightListX = pos.dx + object.size.width;
-        RenderBox box = listStates[tempListIndex].itemStates[tempItemIndex!].context.findRenderObject() as RenderBox;
+        RenderBox box = listStates[tempListIndex]
+            .itemStates[tempItemIndex!]
+            .context
+            .findRenderObject() as RenderBox;
         Offset itemPos = box.localToGlobal(Offset.zero);
         topItemY = itemPos.dy;
         bottomItemY = itemPos.dy + box.size.height;
@@ -206,8 +250,8 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
         });
       });
     }
-    if(mounted){
-      setState(() { });
+    if (mounted) {
+      setState(() {});
     }
   }
 
@@ -216,7 +260,7 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
     var listState = listStates[draggedListIndex!];
     widget.lists!.removeAt(draggedListIndex!);
     listStates.removeAt(draggedListIndex!);
-    if(draggedListIndex != null){
+    if (draggedListIndex != null) {
       draggedListIndex = draggedListIndex! - 1;
     }
     widget.lists!.insert(draggedListIndex!, list);
@@ -225,9 +269,12 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
     if (boardViewController != null && boardViewController.hasClients) {
       int? tempListIndex = draggedListIndex;
       boardViewController
-          .animateTo(draggedListIndex! * widget.width, duration: new Duration(milliseconds: widget.dragDelay), curve: Curves.ease)
+          .animateTo(draggedListIndex! * widget.width,
+              duration: new Duration(milliseconds: widget.dragDelay),
+              curve: Curves.ease)
           .whenComplete(() {
-        RenderBox object = listStates[tempListIndex!].context.findRenderObject() as RenderBox;
+        RenderBox object =
+            listStates[tempListIndex!].context.findRenderObject() as RenderBox;
         Offset pos = object.localToGlobal(Offset.zero);
         leftListX = pos.dx;
         rightListX = pos.dx + object.size.width;
@@ -236,7 +283,7 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
         });
       });
     }
-    if(mounted) {
+    if (mounted) {
       setState(() {});
     }
   }
@@ -246,17 +293,21 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
     var itemState = listStates[draggedListIndex!].itemStates[draggedItemIndex!];
     widget.lists![draggedListIndex!].items!.removeAt(draggedItemIndex!);
     listStates[draggedListIndex!].itemStates.removeAt(draggedItemIndex!);
-    if(listStates[draggedListIndex!].mounted) {
+    if (listStates[draggedListIndex!].mounted) {
       listStates[draggedListIndex!].setState(() {});
     }
-    if(draggedListIndex != null){
+    if (draggedListIndex != null) {
       draggedListIndex = draggedListIndex! - 1;
     }
     double closestValue = 10000;
     draggedItemIndex = 0;
     for (int i = 0; i < listStates[draggedListIndex!].itemStates.length; i++) {
-      if (listStates[draggedListIndex!].itemStates[i].mounted && listStates[draggedListIndex!].itemStates[i].context != null) {
-        RenderBox box = listStates[draggedListIndex!].itemStates[i].context.findRenderObject() as RenderBox;
+      if (listStates[draggedListIndex!].itemStates[i].mounted &&
+          listStates[draggedListIndex!].itemStates[i].context != null) {
+        RenderBox box = listStates[draggedListIndex!]
+            .itemStates[i]
+            .context
+            .findRenderObject() as RenderBox;
         Offset pos = box.localToGlobal(Offset.zero);
         var temp = (pos.dy - dy! + (box.size.height / 2)).abs();
         if (temp < closestValue) {
@@ -267,22 +318,29 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
       }
     }
     widget.lists![draggedListIndex!].items!.insert(draggedItemIndex!, item);
-    listStates[draggedListIndex!].itemStates.insert(draggedItemIndex!, itemState);
+    listStates[draggedListIndex!]
+        .itemStates
+        .insert(draggedItemIndex!, itemState);
     canDrag = false;
-    if(listStates[draggedListIndex!].mounted) {
+    if (listStates[draggedListIndex!].mounted) {
       listStates[draggedListIndex!].setState(() {});
     }
     if (boardViewController != null && boardViewController.hasClients) {
       int? tempListIndex = draggedListIndex;
       int? tempItemIndex = draggedItemIndex;
       boardViewController
-          .animateTo(draggedListIndex! * widget.width, duration: new Duration(milliseconds: 400), curve: Curves.ease)
+          .animateTo(draggedListIndex! * widget.width,
+              duration: new Duration(milliseconds: 400), curve: Curves.ease)
           .whenComplete(() {
-        RenderBox object = listStates[tempListIndex!].context.findRenderObject() as RenderBox;
+        RenderBox object =
+            listStates[tempListIndex!].context.findRenderObject() as RenderBox;
         Offset pos = object.localToGlobal(Offset.zero);
         leftListX = pos.dx;
         rightListX = pos.dx + object.size.width;
-        RenderBox box = listStates[tempListIndex].itemStates[tempItemIndex!].context.findRenderObject() as RenderBox;
+        RenderBox box = listStates[tempListIndex]
+            .itemStates[tempItemIndex!]
+            .context
+            .findRenderObject() as RenderBox;
         Offset itemPos = box.localToGlobal(Offset.zero);
         topItemY = itemPos.dy;
         bottomItemY = itemPos.dy + box.size.height;
@@ -291,7 +349,7 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
         });
       });
     }
-    if(mounted) {
+    if (mounted) {
       setState(() {});
     }
   }
@@ -303,13 +361,13 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
     // print("dy:${dy}");
     // print("topListY:${topListY}");
     // print("bottomListY:${bottomListY}");
-    WidgetsBinding.instance!.addPostFrameCallback((Duration duration) {
-      if(boardViewController.hasClients) {
+    WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
+      if (boardViewController.hasClients) {
         try {
           boardViewController.position.didUpdateScrollPositionBy(0);
-        }catch(e){}
-        bool _shown = boardViewController.position.maxScrollExtent!=0;
-        if(_shown != shown){
+        } catch (e) {}
+        bool _shown = boardViewController.position.maxScrollExtent != 0;
+        if (_shown != shown) {
           setState(() {
             shown = _shown;
           });
@@ -370,31 +428,32 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
         }
       },
     );
-    if(widget.scrollbar == true){
+    if (widget.scrollbar == true) {
       listWidget = VsScrollbar(
           controller: boardViewController,
-          showTrackOnHover: true,// default false
-          isAlwaysShown: shown&&widget.lists!.length>1, // default false
-          scrollbarFadeDuration: Duration(milliseconds: 500), // default : Duration(milliseconds: 300)
-          scrollbarTimeToFade: Duration(milliseconds: 800),// default : Duration(milliseconds: 600)
-          style: widget.scrollbarStyle!=null?VsScrollbarStyle(
-            hoverThickness: widget.scrollbarStyle!.hoverThickness,
-            radius: widget.scrollbarStyle!.radius,
-            thickness: widget.scrollbarStyle!.thickness,
-            color: widget.scrollbarStyle!.color
-          ):VsScrollbarStyle(),
-          child:listWidget);
+          showTrackOnHover: true, // default false
+          isAlwaysShown: shown && widget.lists!.length > 1, // default false
+          scrollbarFadeDuration: Duration(
+              milliseconds: 500), // default : Duration(milliseconds: 300)
+          scrollbarTimeToFade: Duration(
+              milliseconds: 800), // default : Duration(milliseconds: 600)
+          style: widget.scrollbarStyle != null
+              ? VsScrollbarStyle(
+                  hoverThickness: widget.scrollbarStyle!.hoverThickness,
+                  radius: widget.scrollbarStyle!.radius,
+                  thickness: widget.scrollbarStyle!.thickness,
+                  color: widget.scrollbarStyle!.color)
+              : VsScrollbarStyle(),
+          child: listWidget);
     }
-    List<Widget> stackWidgets = <Widget>[
-      listWidget
-    ];
+    List<Widget> stackWidgets = <Widget>[listWidget];
     bool isInBottomWidget = false;
     if (dy != null) {
       if (MediaQuery.of(context).size.height - dy! < 80) {
         isInBottomWidget = true;
       }
     }
-    if(widget.itemInMiddleWidget != null && _isInWidget != isInBottomWidget) {
+    if (widget.itemInMiddleWidget != null && _isInWidget != isInBottomWidget) {
       widget.itemInMiddleWidget!(isInBottomWidget);
       _isInWidget = isInBottomWidget;
     }
@@ -407,15 +466,21 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
         height != null &&
         widget.width != null) {
       if (canDrag && dxInit != null && dyInit != null && !isInBottomWidget) {
-        if (draggedItemIndex != null && draggedItem != null && topItemY != null && bottomItemY != null) {
+        if (draggedItemIndex != null &&
+            draggedItem != null &&
+            topItemY != null &&
+            bottomItemY != null) {
           //dragging item
           if (0 <= draggedListIndex! - 1 && dx! < leftListX! + 45) {
             //scroll left
             if (boardViewController != null && boardViewController.hasClients) {
-              boardViewController.animateTo(boardViewController.position.pixels - 5,
-                  duration: new Duration(milliseconds: 10), curve: Curves.ease);
-              if(listStates[draggedListIndex!].mounted) {
-                RenderBox object = listStates[draggedListIndex!].context
+              boardViewController.animateTo(
+                  boardViewController.position.pixels - 5,
+                  duration: new Duration(milliseconds: 10),
+                  curve: Curves.ease);
+              if (listStates[draggedListIndex!].mounted) {
+                RenderBox object = listStates[draggedListIndex!]
+                    .context
                     .findRenderObject() as RenderBox;
                 Offset pos = object.localToGlobal(Offset.zero);
                 leftListX = pos.dx;
@@ -423,13 +488,17 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
               }
             }
           }
-          if (widget.lists!.length > draggedListIndex! + 1 && dx! > rightListX! - 45) {
+          if (widget.lists!.length > draggedListIndex! + 1 &&
+              dx! > rightListX! - 45) {
             //scroll right
             if (boardViewController != null && boardViewController.hasClients) {
-              boardViewController.animateTo(boardViewController.position.pixels + 5,
-                  duration: new Duration(milliseconds: 10), curve: Curves.ease);
-              if(listStates[draggedListIndex!].mounted) {
-                RenderBox object = listStates[draggedListIndex!].context
+              boardViewController.animateTo(
+                  boardViewController.position.pixels + 5,
+                  duration: new Duration(milliseconds: 10),
+                  curve: Curves.ease);
+              if (listStates[draggedListIndex!].mounted) {
+                RenderBox object = listStates[draggedListIndex!]
+                    .context
                     .findRenderObject() as RenderBox;
                 Offset pos = object.localToGlobal(Offset.zero);
                 leftListX = pos.dx;
@@ -441,48 +510,66 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
             //move left
             moveLeft();
           }
-          if (widget.lists!.length > draggedListIndex! + 1 && dx! > rightListX!) {
+          if (widget.lists!.length > draggedListIndex! + 1 &&
+              dx! > rightListX!) {
             //move right
             moveRight();
           }
           if (dy! < topListY! + 70) {
             //scroll up
             if (listStates[draggedListIndex!].boardListController != null &&
-                listStates[draggedListIndex!].boardListController.hasClients && !isScrolling) {
+                listStates[draggedListIndex!].boardListController.hasClients &&
+                !isScrolling) {
               isScrolling = true;
-              double pos = listStates[draggedListIndex!].boardListController.position.pixels;
-              listStates[draggedListIndex!].boardListController.animateTo(
-                  listStates[draggedListIndex!].boardListController.position.pixels - 5,
-                  duration: new Duration(milliseconds: 10),
-                  curve: Curves.ease).whenComplete((){
-
-                pos -= listStates[draggedListIndex!].boardListController.position.pixels;
-                if(initialY == null)
-                  initialY = 0;
+              double pos = listStates[draggedListIndex!]
+                  .boardListController
+                  .position
+                  .pixels;
+              listStates[draggedListIndex!]
+                  .boardListController
+                  .animateTo(
+                      listStates[draggedListIndex!]
+                              .boardListController
+                              .position
+                              .pixels -
+                          5,
+                      duration: new Duration(milliseconds: 10),
+                      curve: Curves.ease)
+                  .whenComplete(() {
+                pos -= listStates[draggedListIndex!]
+                    .boardListController
+                    .position
+                    .pixels;
+                if (initialY == null) initialY = 0;
 //                if(widget.boardViewController != null) {
 //                  initialY -= pos;
 //                }
                 isScrolling = false;
-                if(topItemY != null) {
+                if (topItemY != null) {
                   topItemY = topItemY! + pos;
                 }
-                if(bottomItemY != null) {
+                if (bottomItemY != null) {
                   bottomItemY = bottomItemY! + pos;
                 }
-                if(mounted){
-                  setState(() { });
+                if (mounted) {
+                  setState(() {});
                 }
               });
             }
           }
           if (0 <= draggedItemIndex! - 1 &&
-              dy! < topItemY! - listStates[draggedListIndex!].itemStates[draggedItemIndex! - 1].height / 2) {
+              dy! <
+                  topItemY! -
+                      listStates[draggedListIndex!]
+                              .itemStates[draggedItemIndex! - 1]
+                              .height /
+                          2) {
             //move up
             moveUp();
           }
           double? tempBottom = bottomListY;
-          if(widget.middleWidget != null){
-            if(_middleWidgetKey.currentContext != null) {
+          if (widget.middleWidget != null) {
+            if (_middleWidgetKey.currentContext != null) {
               RenderBox _box = _middleWidgetKey.currentContext!
                   .findRenderObject() as RenderBox;
               tempBottom = _box.size.height;
@@ -495,32 +582,50 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
             if (listStates[draggedListIndex!].boardListController != null &&
                 listStates[draggedListIndex!].boardListController.hasClients) {
               isScrolling = true;
-              double pos = listStates[draggedListIndex!].boardListController.position.pixels;
-              listStates[draggedListIndex!].boardListController.animateTo(
-                  listStates[draggedListIndex!].boardListController.position.pixels + 5,
-                  duration: new Duration(milliseconds: 10),
-                  curve: Curves.ease).whenComplete((){
-                pos -= listStates[draggedListIndex!].boardListController.position.pixels;
-                if(initialY == null)
-                  initialY = 0;
+              double pos = listStates[draggedListIndex!]
+                  .boardListController
+                  .position
+                  .pixels;
+              listStates[draggedListIndex!]
+                  .boardListController
+                  .animateTo(
+                      listStates[draggedListIndex!]
+                              .boardListController
+                              .position
+                              .pixels +
+                          5,
+                      duration: new Duration(milliseconds: 10),
+                      curve: Curves.ease)
+                  .whenComplete(() {
+                pos -= listStates[draggedListIndex!]
+                    .boardListController
+                    .position
+                    .pixels;
+                if (initialY == null) initialY = 0;
 //                if(widget.boardViewController != null) {
 //                  initialY -= pos;
 //                }
                 isScrolling = false;
-                if(topItemY != null) {
+                if (topItemY != null) {
                   topItemY = topItemY! + pos;
                 }
-                if(bottomItemY != null) {
+                if (bottomItemY != null) {
                   bottomItemY = bottomItemY! + pos;
                 }
-                if(mounted){
+                if (mounted) {
                   setState(() {});
                 }
               });
             }
           }
-          if (widget.lists![draggedListIndex!].items!.length > draggedItemIndex! + 1 &&
-              dy! > bottomItemY! + listStates[draggedListIndex!].itemStates[draggedItemIndex! + 1].height / 2) {
+          if (widget.lists![draggedListIndex!].items!.length >
+                  draggedItemIndex! + 1 &&
+              dy! >
+                  bottomItemY! +
+                      listStates[draggedListIndex!]
+                              .itemStates[draggedItemIndex! + 1]
+                              .height /
+                          2) {
             //move down
             moveDown();
           }
@@ -529,31 +634,37 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
           if (0 <= draggedListIndex! - 1 && dx! < leftListX! + 45) {
             //scroll left
             if (boardViewController != null && boardViewController.hasClients) {
-              boardViewController.animateTo(boardViewController.position.pixels - 5,
-                  duration: new Duration(milliseconds: 10), curve: Curves.ease);
-              if(leftListX != null){
+              boardViewController.animateTo(
+                  boardViewController.position.pixels - 5,
+                  duration: new Duration(milliseconds: 10),
+                  curve: Curves.ease);
+              if (leftListX != null) {
                 leftListX = leftListX! + 5;
               }
-              if(rightListX != null){
+              if (rightListX != null) {
                 rightListX = rightListX! + 5;
               }
             }
           }
 
-          if (widget.lists!.length > draggedListIndex! + 1 && dx! > rightListX! - 45) {
+          if (widget.lists!.length > draggedListIndex! + 1 &&
+              dx! > rightListX! - 45) {
             //scroll right
             if (boardViewController != null && boardViewController.hasClients) {
-              boardViewController.animateTo(boardViewController.position.pixels + 5,
-                  duration: new Duration(milliseconds: 10), curve: Curves.ease);
-              if(leftListX != null){
+              boardViewController.animateTo(
+                  boardViewController.position.pixels + 5,
+                  duration: new Duration(milliseconds: 10),
+                  curve: Curves.ease);
+              if (leftListX != null) {
                 leftListX = leftListX! - 5;
               }
-              if(rightListX != null){
+              if (rightListX != null) {
                 rightListX = rightListX! - 5;
               }
             }
           }
-          if (widget.lists!.length > draggedListIndex! + 1 && dx! > rightListX!) {
+          if (widget.lists!.length > draggedListIndex! + 1 &&
+              dx! > rightListX!) {
             //move right
             moveListRight();
           }
@@ -564,10 +675,11 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
         }
       }
       if (widget.middleWidget != null) {
-        stackWidgets.add(Container(key:_middleWidgetKey,child:widget.middleWidget));
+        stackWidgets
+            .add(Container(key: _middleWidgetKey, child: widget.middleWidget));
       }
-      WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
-        if(mounted){
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        if (mounted) {
           setState(() {});
         }
       });
@@ -592,7 +704,7 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
                 }
                 dx = opm.position.dx;
                 dy = opm.position.dy;
-                if(mounted) {
+                if (mounted) {
                   setState(() {});
                 }
               }
@@ -603,7 +715,7 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
               offsetX = pos.dx;
               offsetY = pos.dy;
               pointer = opd;
-              if(mounted) {
+              if (mounted) {
                 setState(() {});
               }
             },
@@ -614,19 +726,23 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
                 int? startDraggedItemIndex = startItemIndex;
                 int? startDraggedListIndex = startListIndex;
 
-                if(_isInWidget && widget.onDropItemInMiddleWidget != null){
+                if (_isInWidget && widget.onDropItemInMiddleWidget != null) {
                   onDropItem!(startDraggedListIndex, startDraggedItemIndex);
-                  widget.onDropItemInMiddleWidget!(startDraggedListIndex, startDraggedItemIndex,opu.position.dx/MediaQuery.of(context).size.width);
-                }else{
+                  widget.onDropItemInMiddleWidget!(
+                      startDraggedListIndex,
+                      startDraggedItemIndex,
+                      opu.position.dx / MediaQuery.of(context).size.width);
+                } else {
                   onDropItem!(tempDraggedListIndex, tempDraggedItemIndex);
                 }
               }
               if (onDropList != null) {
                 int? tempDraggedListIndex = draggedListIndex;
-                if(_isInWidget && widget.onDropItemInMiddleWidget != null){
+                if (_isInWidget && widget.onDropItemInMiddleWidget != null) {
                   onDropList!(tempDraggedListIndex);
-                  widget.onDropItemInMiddleWidget!(tempDraggedListIndex,null,opu.position.dx/MediaQuery.of(context).size.width);
-                }else{
+                  widget.onDropItemInMiddleWidget!(tempDraggedListIndex, null,
+                      opu.position.dx / MediaQuery.of(context).size.width);
+                } else {
                   onDropList!(tempDraggedListIndex);
                 }
               }
@@ -651,7 +767,7 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
               bottomItemY = null;
               startListIndex = null;
               startItemIndex = null;
-              if(mounted) {
+              if (mounted) {
                 setState(() {});
               }
             },
@@ -664,17 +780,21 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
     if (pointer != null) {
       dx = pointer.position.dx;
       dy = pointer.position.dy;
-      if(mounted) {
+      if (mounted) {
         setState(() {});
       }
     }
   }
 }
 
-class ScrollbarStyle{
+class ScrollbarStyle {
   double hoverThickness;
   double thickness;
   Radius radius;
   Color color;
-  ScrollbarStyle({this.radius = const Radius.circular(10),this.hoverThickness = 10,this.thickness = 10,this.color = Colors.black});
+  ScrollbarStyle(
+      {this.radius = const Radius.circular(10),
+      this.hoverThickness = 10,
+      this.thickness = 10,
+      this.color = Colors.black});
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +66,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -127,28 +134,21 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   vs_scrollbar:
     dependency: "direct main"
     description:
       name: vs_scrollbar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: boardview
 description: This is a custom Flutter widget that can create a draggable BoardView or also known as a kanban. The view can be reordered with drag and drop.
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/jakebonk/FlutterBoardView
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: boardview
 description: This is a custom Flutter widget that can create a draggable BoardView or also known as a kanban. The view can be reordered with drag and drop.
-version: 0.2.2
+version: 0.2.3
 homepage: https://github.com/jakebonk/FlutterBoardView
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  vs_scrollbar: ^0.2.0
+  vs_scrollbar: ^0.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I kept getting an exception here when using this package in a `LayoutBuilder`, which sometimes removed the panel containing it - which caused the exception.  I see you already have a similar fix (`boardViewController.hasClients`), but that conditional was placed in the wrong place I thin (outside the `addPostFrameCallback`.  Placing it inside the callback, seems to fix it:

```
WidgetsBinding.instance!.addPostFrameCallback((Duration duration) {
      if(boardViewController.hasClients) {
        try {
          boardViewController.position.didUpdateScrollPositionBy(0);
        }catch(e){}
        bool _shown = boardViewController.position.maxScrollExtent!=0;
        if(_shown != shown){
          setState(() {
            shown = _shown;
          });
        }
      }
    });
```

I also bumped the version.

Note that this package seems to use another, `vs_scrollbar`, which isn't well maintained. In my local use of your package, I have to do this to get it all to work:

```
dependency_overrides:
  vs_scrollbar:
    git:
      url: https://github.com/jonmountjoy/vs_scrollbar
      ref: isPointerOverScrollbarChange
```